### PR TITLE
fix add keyword trim when add user

### DIFF
--- a/primihub-service/biz/src/main/java/com/primihub/biz/service/sys/SysUserService.java
+++ b/primihub-service/biz/src/main/java/com/primihub/biz/service/sys/SysUserService.java
@@ -170,10 +170,12 @@ public class SysUserService {
         Long userId=saveOrUpdateUserParam.getUserId();
         SysUser sysUser;
         if(userId==null){
-            if(saveOrUpdateUserParam.getUserAccount()==null|| "".equals(saveOrUpdateUserParam.getUserAccount().trim())) {
+            saveOrUpdateUserParam.setUserAccount(saveOrUpdateUserParam.getUserAccount().trim());
+            saveOrUpdateUserParam.setUserName(saveOrUpdateUserParam.getUserName().trim());
+            if(saveOrUpdateUserParam.getUserAccount()==null|| saveOrUpdateUserParam.getUserAccount().isEmpty()) {
                 return BaseResultEntity.failure(BaseResultEnum.LACK_OF_PARAM,"userAccount");
             }
-            if(saveOrUpdateUserParam.getUserName()==null|| "".equals(saveOrUpdateUserParam.getUserName().trim())) {
+            if(saveOrUpdateUserParam.getUserName()==null|| saveOrUpdateUserParam.getUserName().isEmpty()) {
                 return BaseResultEntity.failure(BaseResultEnum.LACK_OF_PARAM,"userName");
             }
             if(saveOrUpdateUserParam.getIsForbid()==null) {


### PR DESCRIPTION
as title says, user key info such as account and username should not contains no blank word when create one new user